### PR TITLE
 Update background image in h6 CSS rule from 'smallImage2.jpg' to '1.…

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1112,7 +1112,8 @@ h6 {
   left: 0;
   width: 21%;
   height: 52%;
-  background-image: url(/assets/img/smallImage2.jpg);
+  /* background-image: url(/assets/img/smallImage2.jpg); */
+  background-image: url(/assets/img/1.jpg);
   background-size: cover;
   z-index: -1;
   margin-left: 176vh;


### PR DESCRIPTION
…jpg'

This commit updates the background image specified in the CSS rule for h6 elements. The original image path '/assets/img/smallImage2.jpg' is commented out and replaced with the new image path '/assets/img/1.jpg'.